### PR TITLE
Replace requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,12 +2,12 @@ from setuptools import setup, find_packages
 
 setup(
     name="StatisticsTracker",	     # This is the name of your PyPI-package.
-    version="0.1.0",		     # Update the version number for new releases
+    version="0.1.1",		     # Update the version number for new releases
     description="Statistics capture and saving",
     author="Daniel Grecoe",
     author_email="grecoe@microsoft.com",
     url="https://github.com/microsoft/StatisticsTracker",
     license="MIT",
     packages=find_packages(),
-    install_requires=["azure-cli-core", "azure-storage-blob"]
+    install_requires=["azure-cli"]
 )


### PR DESCRIPTION
This fixes problems with the azure-storage-blob requirement having name collisions